### PR TITLE
chore: PR ワークフロー規約の整備（docs チェック必須化＋ブランチ命名ルール）

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -14,8 +14,12 @@ PR を作成するときは次に従う。
    - 変更が他 docs（`architecture.md` / `infrastructure.md` / `auth.md` / `content-pipeline.md` 等）の
      記述に波及していないか `grep -rn <キーワード> docs --include=*.md` で確認。
    - docs は **Markdown が正本**。`docs/_site/` は生成物・**git 管理外**なので再生成・コミットは不要。
-3. ブランチは Issue 単位（`main` で直接作業しない）。本文は
-   [`.github/pull_request_template.md`](../../../.github/pull_request_template.md)（概要 / コード / テスト）に従う。
+3. ブランチ名は規約に従う（`main` で直接作業しない。説明・単語間は**スネークケース `_`**）:
+   - Issue あり: `#<番号>_<説明>`（例: `#18_admin_media` / `#39_fix_hydration_nesting`）。
+   - Issue 無し: `<種別>/<説明>`（例: `chore/create_pr_docs_check` / `docs/readme_fixup` / `revert/pr_37`）。
+     種別は Conventional Commits 系（feat / fix / docs / chore / refactor / revert 等）。
+
+   本文は [`.github/pull_request_template.md`](../../../.github/pull_request_template.md)（概要 / コード / テスト）に従う。
 4. 対応する Issue があれば、本文冒頭に `close #<Issue番号>`（GitHub の closing keyword）を入れる。
    これで `main` へのマージ時に対象 Issue が自動クローズされる。Issue を伴わない PR では省略してよい。
 5. `gh pr create` で作成する（`.claude/settings.json` で自動許可済み）。

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -7,8 +7,15 @@ when_to_use: PR を作る / プルリクエストを出す / gh pr create する
 PR を作成するときは次に従う。
 
 1. まず `/pre-pr`（`pnpm lint` ＋ `npx tsc --noEmit`）を通す。失敗したら PR 作成に進まない。
-2. ブランチは Issue 単位（`main` で直接作業しない）。本文は
+2. **PR 作成前にドキュメントの整合を必ず確認する**（不整合があれば PR 作成前に同ブランチで修正コミット）:
+   - ルート/スキーマを変えたら [`docs/routing.md`](../../../docs/routing.md)（状態欄・リンク）と
+     [`docs/data-model.md`](../../../docs/data-model.md) を同 PR で更新（CLAUDE.md の規約）。
+   - 機能・ロードマップ項目を実装したら [`docs/roadmap.md`](../../../docs/roadmap.md) の該当行を更新し routing.md へ昇格。
+   - 変更が他 docs（`architecture.md` / `infrastructure.md` / `auth.md` / `content-pipeline.md` 等）の
+     記述に波及していないか `grep -rn <キーワード> docs --include=*.md` で確認。
+   - docs は **Markdown が正本**。`docs/_site/` は生成物・**git 管理外**なので再生成・コミットは不要。
+3. ブランチは Issue 単位（`main` で直接作業しない）。本文は
    [`.github/pull_request_template.md`](../../../.github/pull_request_template.md)（概要 / コード / テスト）に従う。
-3. 対応する Issue があれば、本文冒頭に `close #<Issue番号>`（GitHub の closing keyword）を入れる。
+4. 対応する Issue があれば、本文冒頭に `close #<Issue番号>`（GitHub の closing keyword）を入れる。
    これで `main` へのマージ時に対象 Issue が自動クローズされる。Issue を伴わない PR では省略してよい。
-4. `gh pr create` で作成する（`.claude/settings.json` で自動許可済み）。
+5. `gh pr create` で作成する（`.claude/settings.json` で自動許可済み）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,9 @@
 
 ## ワークフロー（Human on the loop）
 
-- ブランチは Issue 単位。既存の命名（例: `#8_admin_posts_list`）に倣う。`main` で直接作業しない。
+- ブランチ名（`main` で直接作業しない。説明・単語間は**スネークケース `_`**）:
+  - Issue あり: `#<番号>_<説明>`（例: `#18_admin_media`）。
+  - Issue 無し: `<種別>/<説明>`（例: `chore/create_pr_docs_check`、種別は feat/fix/docs/chore/refactor/revert 等）。
 - 機能実装は **plan mode** で計画 → 承認 → 実装。
 - PR 前に `pnpm lint`（必要なら `npx tsc --noEmit`）を通す。
 - PR は [`.github/pull_request_template.md`](./.github/pull_request_template.md)（概要 / コード / テスト）に従う。

--- a/docs/development.md
+++ b/docs/development.md
@@ -29,7 +29,9 @@
 
 ## ワークフロー（Human on the loop）
 
-- ブランチは Issue 単位（既存命名 `#8_admin_posts_list` に倣う）。`main` で直接作業しない。
+- ブランチ名（`main` で直接作業しない。説明・単語間は**スネークケース `_`**）:
+  - Issue あり: `#<番号>_<説明>`（例: `#18_admin_media`）。
+  - Issue 無し: `<種別>/<説明>`（例: `chore/create_pr_docs_check`、種別は feat/fix/docs/chore/refactor/revert 等）。
 - 機能実装は plan mode で計画 → 承認 → 実装。
 - PR 前に `pnpm lint`（必要なら `npx tsc --noEmit`）。PR は [`../.github/pull_request_template.md`](../.github/pull_request_template.md) に従う。
 - **PR 作成前に必ず docs の整合をチェックする**（[`../.claude/skills/create-pr/SKILL.md`](../.claude/skills/create-pr/SKILL.md) の手順）。不整合は PR 前に同ブランチで修正する。

--- a/docs/development.md
+++ b/docs/development.md
@@ -32,6 +32,7 @@
 - ブランチは Issue 単位（既存命名 `#8_admin_posts_list` に倣う）。`main` で直接作業しない。
 - 機能実装は plan mode で計画 → 承認 → 実装。
 - PR 前に `pnpm lint`（必要なら `npx tsc --noEmit`）。PR は [`../.github/pull_request_template.md`](../.github/pull_request_template.md) に従う。
+- **PR 作成前に必ず docs の整合をチェックする**（[`../.claude/skills/create-pr/SKILL.md`](../.claude/skills/create-pr/SKILL.md) の手順）。不整合は PR 前に同ブランチで修正する。
 - 破壊的スクリプト・push・PR 作成・依存変更は確認プロンプトが出る（[`../.claude/settings.json`](../.claude/settings.json) の `ask`）。
 
 ## 既知の負債


### PR DESCRIPTION
## 概要

PR まわりの運用規約を 2 点整備する。

1. **PR 作成前のドキュメント整合チェックを必須化**（PR #42 でユーザー指摘を受けて恒常化）。
2. **ブランチ命名ルールの明文化**（既存の混在を解消）。

## コード

- `.claude/skills/create-pr/SKILL.md`:
  - `/pre-pr` の直後に手順「ドキュメント整合チェック（必須）」を追加。
  - ブランチ手順を命名規約に差し替え。
- `CLAUDE.md` / `docs/development.md`: ワークフロー節にドキュメントチェックとブランチ命名ルールを反映。

### ブランチ命名ルール

- `main` で直接作業しない。説明・単語間は**スネークケース `_`**。
- Issue あり: `#<番号>_<説明>`（例: `#18_admin_media` / `#39_fix_hydration_nesting`）。
- Issue 無し: `<種別>/<説明>`（例: `chore/create_pr_docs_check` / `docs/readme_fixup` / `revert/pr_37`）。種別は Conventional Commits 系。

## テスト

- `pnpm lint`・`npx tsc --noEmit` グリーン（ドキュメント/スキルのみの変更）。
- 本 PR 自体で新手順をドッグフーディング: ドキュメントチェックで `docs/development.md` の更新漏れを検出・反映。

🤖 Generated with [Claude Code](https://claude.com/claude-code)