### PR TITLE
fix: モバイルメニューの hydration mismatch を解消 (#41)

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,20 +1,17 @@
 import Link from "next/link";
-import { ModeToggle, ModeToggleMobile } from "@/components/ThemeToggle";
+import { ModeToggle } from "@/components/ThemeToggle";
+import { MobileNav } from "@/components/MobileNav";
 import { Button } from "./ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuGroup,
-} from "@/components/ui/dropdown-menu";
-import { MenuIcon } from "lucide-react";
 import { auth, signOut } from "@/auth";
 
 export default async function Header() {
   const session = await auth();
   const isLoggedIn = !!session?.user;
+
+  async function signOutAction() {
+    "use server";
+    await signOut({ redirectTo: "/" });
+  }
 
   return (
     <nav className="fixed top-0 left-0 w-full bg-[var(--background)]/30 backdrop-blur-sm z-50 py-4 px-6 flex justify-between items-center text-sm shadow-sm">
@@ -37,12 +34,7 @@ export default async function Header() {
           </li>
           <li>
             {isLoggedIn ? (
-              <form
-                action={async () => {
-                  "use server";
-                  await signOut({ redirectTo: "/" });
-                }}
-              >
+              <form action={signOutAction}>
                 <Button variant="default" size="lg">
                   ログアウト
                 </Button>
@@ -61,48 +53,7 @@ export default async function Header() {
 
       {/* Mobile Navigation */}
       <div className="block md:hidden">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="lg">
-              <MenuIcon />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent>
-            <DropdownMenuGroup>
-              <DropdownMenuItem asChild>
-                <Link href="/about">ブログについて</Link>
-              </DropdownMenuItem>
-            </DropdownMenuGroup>
-            <DropdownMenuSeparator />
-            <DropdownMenuGroup>
-              <DropdownMenuItem asChild>
-                <Link href="/admin">管理用</Link>
-              </DropdownMenuItem>
-              {isLoggedIn ? (
-                <form
-                  action={async () => {
-                    "use server";
-                    await signOut({ redirectTo: "/" });
-                  }}
-                >
-                  <DropdownMenuItem asChild>
-                    <button type="submit" className="w-full text-left">
-                      ログアウト
-                    </button>
-                  </DropdownMenuItem>
-                </form>
-              ) : (
-                <DropdownMenuItem asChild>
-                  <Link href="/login">ログイン</Link>
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuGroup>
-            <DropdownMenuSeparator />
-            <DropdownMenuGroup>
-              <ModeToggleMobile />
-            </DropdownMenuGroup>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <MobileNav isLoggedIn={isLoggedIn} signOutAction={signOutAction} />
       </div>
     </nav>
   );

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -25,6 +25,7 @@ export function MobileNav({
       <DropdownMenuTrigger asChild>
         <Button variant="outline" size="lg">
           <MenuIcon />
+          <span className="sr-only">メニュー</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent>

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Link from "next/link";
+import { MenuIcon } from "lucide-react";
+import { ModeToggleMobile } from "@/components/ThemeToggle";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuGroup,
+} from "@/components/ui/dropdown-menu";
+
+export function MobileNav({
+  isLoggedIn,
+  signOutAction,
+}: {
+  isLoggedIn: boolean;
+  signOutAction: () => Promise<void>;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="lg">
+          <MenuIcon />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuGroup>
+          <DropdownMenuItem asChild>
+            <Link href="/about">ブログについて</Link>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          <DropdownMenuItem asChild>
+            <Link href="/admin">管理用</Link>
+          </DropdownMenuItem>
+          {isLoggedIn ? (
+            <form action={signOutAction}>
+              <DropdownMenuItem asChild>
+                <button type="submit" className="w-full text-left">
+                  ログアウト
+                </button>
+              </DropdownMenuItem>
+            </form>
+          ) : (
+            <DropdownMenuItem asChild>
+              <Link href="/login">ログイン</Link>
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          <ModeToggleMobile />
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
- close #41

## 概要

全ページ共通の `Header`（モバイルメニュー）で発生していた **Hydration mismatch** を解消する。

シークレットウィンドウでも再現したため拡張起因ではなく、真の SSR/CSR 差異と確定。調査の結果、原因は当初想定（next-themes / Radix `useId`）ではなく、**モバイルナビの Radix `DropdownMenu` を async Server Component（`Header`）内に直接描画していたこと**だった。

- サーバーでは当該サブツリーが描画されず空の `<div>` になり、クライアントでのみトリガー `<button>` が生成 → 構造不一致で mismatch。
- 生 SSR HTML で確認：修正前は `aria-haspopup="menu"` が **1**（desktop の `ModeToggle` のみ）、モバイル `<div>` は空。`MenuIcon` は RSC flight payload にのみ存在。
- 動作している desktop の `ModeToggle` は `"use client"` コンポーネント内にあるため正常に SSR されていた。

## コード

- `components/MobileNav.tsx`（新規・`"use client"`）: モバイルの `DropdownMenu` を切り出し。`isLoggedIn` と `signOutAction` を props で受け取る。
- `components/Header.tsx`: モバイルメニューを `<MobileNav />` 利用に変更。`signOut` を サーバーアクション `signOutAction` として共通化し desktop/mobile で再利用（インライン重複を削除）。
- ルート/スキーマ変更なし → `docs/` の更新は不要。

## テスト

- `pnpm lint` / `npx tsc --noEmit` パス。
- 生 SSR HTML を確認：修正後は `aria-haspopup="menu"` が **2**（desktop + mobile）、モバイル `<div>` 内に `<button data-slot="dropdown-menu-trigger" data-size="lg">` がサーバー描画される（server/client のツリー一致）。
- ブラウザ実機で確認済み：コンソールの hydration エラーが消え、モバイルメニュー開閉・テーマ切替・ログイン/ログアウト表示が正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)