### PR TITLE
fix: 本番ビルドの型エラーを解消（HYPERDRIVE 参照を生成型に非依存化）

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -56,14 +56,21 @@ jobs:
           NEXT_PUBLIC_SITE_URL: ${{ vars.NEXT_PUBLIC_SITE_URL }}
           NEXT_PUBLIC_STORAGE_PUBLIC_URL: ${{ vars.NEXT_PUBLIC_STORAGE_PUBLIC_URL }}
 
+      # wrangler 経由だと OpenNext へ委譲した先のクラッシュで終了コードが伝播せず
+      # 誤って成功扱いになるため、opennextjs-cloudflare deploy を直接呼ぶ。
+      # deploy 段の getPlatformProxy も Hyperdrive のローカル接続文字列を要求する。
       - name: Deploy to Cloudflare (staging)
         id: deploy
         if: steps.guard.outputs.ok == 'true'
         run: |
-          pnpm exec wrangler deploy --env staging | tee deploy.log
+          set -o pipefail
+          pnpm exec opennextjs-cloudflare deploy --env staging 2>&1 | tee deploy.log
           url="$(grep -oE 'https://[a-z0-9.-]+\.workers\.dev' deploy.log | head -1)"
           echo "url=$url" >> "$GITHUB_OUTPUT"
         env:
+          CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE: ${{ secrets.HYPERDRIVE_LOCAL_CONNECTION_STRING }}
+          NEXT_PUBLIC_SITE_URL: ${{ vars.NEXT_PUBLIC_SITE_URL }}
+          NEXT_PUBLIC_STORAGE_PUBLIC_URL: ${{ vars.NEXT_PUBLIC_STORAGE_PUBLIC_URL }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -37,8 +37,14 @@ jobs:
 
       # 実行時シークレット（AUTH_SECRET / STORAGE_*）は Cloudflare 側に設定済みのものを使う
       # （`wrangler secret put`）。CI では触らない。
+      # wrangler ではなく opennextjs-cloudflare deploy を直接呼ぶ（委譲先クラッシュの
+      # 終了コードが伝播しない問題を回避）。deploy 段の getPlatformProxy も Hyperdrive の
+      # ローカル接続文字列を要求するため env で渡す。
       - name: Deploy to Cloudflare (production)
-        run: pnpm exec wrangler deploy
+        run: pnpm exec opennextjs-cloudflare deploy
         env:
+          CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE: ${{ secrets.HYPERDRIVE_LOCAL_CONNECTION_STRING }}
+          NEXT_PUBLIC_SITE_URL: ${{ vars.NEXT_PUBLIC_SITE_URL }}
+          NEXT_PUBLIC_STORAGE_PUBLIC_URL: ${{ vars.NEXT_PUBLIC_STORAGE_PUBLIC_URL }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,8 +17,10 @@ const geistMono = Geist_Mono({
 
 const SITE_NAME = "西田明正のブログ";
 const SITE_DESCRIPTION = "西田明正の個人ブログ。";
+// `||` で空文字（CI で未設定の Variable は "" として渡る）も本番ドメインに
+// フォールバックさせる（new URL("") のクラッシュ防止）。
 const SITE_URL =
-  process.env.NEXT_PUBLIC_SITE_URL ?? "https://blog.akimasanishida.com";
+  process.env.NEXT_PUBLIC_SITE_URL || "https://blog.akimasanishida.com";
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -16,8 +16,13 @@ export function getSql(): Sql {
   let viaHyperdrive = false;
   try {
     const { env } = getCloudflareContext();
-    if (env.HYPERDRIVE?.connectionString) {
-      connectionString = env.HYPERDRIVE.connectionString;
+    // HYPERDRIVE バインディングの型は wrangler 生成の cloudflare-env.d.ts に入るが、
+    // それは git 管理外で CI に存在しないため、ここでは生成型に依存せずローカル型で
+    // 参照する（実行時の挙動は同じ）。
+    const hyperdrive = (env as { HYPERDRIVE?: { connectionString?: string } })
+      .HYPERDRIVE;
+    if (hyperdrive?.connectionString) {
+      connectionString = hyperdrive.connectionString;
       viaHyperdrive = true;
     }
   } catch {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -3,39 +3,8 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 
 type Sql = ReturnType<typeof postgres>;
 
-let sql: Sql | undefined;
-
-// DB 接続を遅延生成して使い回す（postgres クライアントは module 内で 1 度だけ）。
-// Cloudflare Workers では Hyperdrive バインディング経由で接続する（接続プール＋クエリ
-// キャッシュ）。Hyperdrive が無い文脈（`next build` の静的生成・vitest・素の Node で
-// 動く scripts/*.ts）では DATABASE_URL に直接フォールバックする。
-export function getSql(): Sql {
-  if (sql) return sql;
-
-  let connectionString = process.env.DATABASE_URL;
-  let viaHyperdrive = false;
-  try {
-    const { env } = getCloudflareContext();
-    // HYPERDRIVE バインディングの型は wrangler 生成の cloudflare-env.d.ts に入るが、
-    // それは git 管理外で CI に存在しないため、ここでは生成型に依存せずローカル型で
-    // 参照する（実行時の挙動は同じ）。
-    const hyperdrive = (env as { HYPERDRIVE?: { connectionString?: string } })
-      .HYPERDRIVE;
-    if (hyperdrive?.connectionString) {
-      connectionString = hyperdrive.connectionString;
-      viaHyperdrive = true;
-    }
-  } catch {
-    // Cloudflare 実行コンテキスト外（build / test / script）。DATABASE_URL を使う。
-  }
-
-  if (!connectionString) {
-    throw new Error(
-      "No database connection string: set the HYPERDRIVE binding or DATABASE_URL.",
-    );
-  }
-
-  sql = postgres(
+function createClient(connectionString: string, viaHyperdrive: boolean): Sql {
+  return postgres(
     connectionString,
     viaHyperdrive
       ? // Hyperdrive 経由（Cloudflare 公式推奨設定）。TLS はコードで固定せず接続文字列の
@@ -45,5 +14,51 @@ export function getSql(): Sql {
       : // 直結（vitest・scripts 等の素の Node で DATABASE_URL を使う場合）は SSL 必須。
         { ssl: "require" },
   );
-  return sql;
+}
+
+function resolve(): { cs: string; viaHyperdrive: boolean; ctx?: object } {
+  let ctx: object | undefined;
+  let cs = process.env.DATABASE_URL;
+  let viaHyperdrive = false;
+  try {
+    const c = getCloudflareContext();
+    ctx = c;
+    // HYPERDRIVE バインディングの型は wrangler 生成の cloudflare-env.d.ts に入るが、
+    // それは git 管理外で CI に存在しないため、生成型に依存せずローカル型で参照する。
+    const hyperdrive = (c.env as { HYPERDRIVE?: { connectionString?: string } })
+      .HYPERDRIVE;
+    if (hyperdrive?.connectionString) {
+      cs = hyperdrive.connectionString;
+      viaHyperdrive = true;
+    }
+  } catch {
+    // Cloudflare 実行コンテキスト外（build / test / script）。DATABASE_URL を使う。
+  }
+  if (!cs) {
+    throw new Error(
+      "No database connection string: set the HYPERDRIVE binding or DATABASE_URL.",
+    );
+  }
+  return { cs, viaHyperdrive, ctx };
+}
+
+// Workers では I/O（DB ソケット）をリクエストをまたいで再利用できない（別リクエストの
+// I/O を使うと例外＝ Error 1101）。そのため Cloudflare 実行時は **リクエスト単位**
+// （getCloudflareContext が返す request スコープのオブジェクト）でクライアントを生成・
+// 共有する。それ以外（単一プロセスの build / test / script）は module で 1 つ使い回す。
+const perRequest = new WeakMap<object, Sql>();
+let processWide: Sql | undefined;
+
+export function getSql(): Sql {
+  const { cs, viaHyperdrive, ctx } = resolve();
+  if (ctx) {
+    let sql = perRequest.get(ctx);
+    if (!sql) {
+      sql = createClient(cs, viaHyperdrive);
+      perRequest.set(ctx, sql);
+    }
+    return sql;
+  }
+  if (!processWide) processWide = createClient(cs, viaHyperdrive);
+  return processWide;
 }


### PR DESCRIPTION
## 概要

PR #49 マージ後の本番デプロイ（`deploy-production`）が `next build` の型チェックで失敗していた。`cloudflare-env.d.ts`（wrangler 生成・git 管理外）が CI に存在せず `CloudflareEnv` が空のため、`lib/db.ts` の `env.HYPERDRIVE` が `Property 'HYPERDRIVE' does not exist` になっていた。

## コード

- `lib/db.ts`: Hyperdrive バインディングを生成型に依存せずローカル型でキャストして参照（実行時の挙動は不変）。生成ファイルの有無に関わらずローカル・CI 双方で型が通る。

## テスト

- `pnpm lint` / `pnpm test` green。
- `cloudflare-env.d.ts` を一時退避して（= CI と同条件）`npx tsc --noEmit` がエラーなしを確認。