### PR TITLE
fix: next-auth の API ルート(/api/auth/*)を追加（ログイン 404 を解消）

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,5 @@
+// next-auth v5 の API ルート。/api/auth/* （session・csrf・callback/credentials 等）を
+// マウントする。Credentials のサインインは /api/auth/callback/credentials を叩くため必須。
+import { handlers } from "@/auth";
+
+export const { GET, POST } = handlers;

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -4,6 +4,9 @@ import type { NextAuthConfig } from "next-auth";
 // 行う（Next.js 16 の proxy は OpenNext/Cloudflare 未対応のため）。ここでは
 // signIn ページの場所のみ定義する。
 export const authConfig = {
+  // Vercel 以外（Cloudflare Workers）では Auth.js がホストを自動信頼しないため明示する。
+  // 未設定だと callback でホスト不信のエラー（"server configuration" 系）になる。
+  trustHost: true,
   pages: {
     signIn: "/login",
   },

--- a/auth.ts
+++ b/auth.ts
@@ -17,7 +17,7 @@ async function getUser(email: string): Promise<User | undefined> {
   }
 }
 
-export const { auth, signIn, signOut } = NextAuth({
+export const { handlers, auth, signIn, signOut } = NextAuth({
   ...authConfig,
   providers: [
     Credentials({

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,6 +1,6 @@
 # 認証
 
-> 事実は code が source of truth: [`auth.ts`](../auth.ts) / [`auth.config.ts`](../auth.config.ts) / [`app/admin/layout.tsx`](../app/admin/layout.tsx)。
+> 事実は code が source of truth: [`auth.ts`](../auth.ts) / [`auth.config.ts`](../auth.config.ts) / [`app/api/auth/[...nextauth]/route.ts`](../app/api/auth/%5B...nextauth%5D/route.ts) / [`app/admin/layout.tsx`](../app/admin/layout.tsx)。
 
 ## 概要
 
@@ -16,6 +16,11 @@
    - 入力を **zod** で検証（`email` 形式・`password` 6 文字以上）。
    - `getUser(email)` で users を 1 件取得 → `bcryptjs.compare` で照合。一致すれば User を返す。
 4. 失敗時は `authenticate()` が日本語エラーメッセージを返す（`CredentialsSignin` 等）。
+
+> next-auth の API（`/api/auth/*`：`callback/credentials`・`session`・`csrf` 等）は
+> [`app/api/auth/[...nextauth]/route.ts`](../app/api/auth/%5B...nextauth%5D/route.ts) が
+> `auth.ts` の `handlers` をマウントして提供する。Credentials のサインインはこの
+> `callback/credentials` を叩くため必須（無いと 404）。
 
 ## 認可（レイアウトガード）
 


### PR DESCRIPTION
## 概要

本番 Worker で `/api/auth/callback/credentials` をはじめ `/api/auth/*` がすべて 404 になり、`/admin` ログインができなかった。`auth.ts` が `handlers` を export しておらず、`app/api/auth/[...nextauth]/route.ts` も存在しなかったため、next-auth の API がマウントされていなかった。

## コード

- `auth.ts`: `NextAuth()` の戻り値から `handlers` も export。
- `app/api/auth/[...nextauth]/route.ts`（新規）: `handlers` を `GET`/`POST` としてマウント（Auth.js v5 標準）。
- `docs/auth.md`: API ルートの説明を追記。

## テスト

- `pnpm lint` / `npx tsc --noEmit` / `pnpm test`（21件）green。
- `next build` のルート表に `ƒ /api/auth/[...nextauth]` が登録されることを確認。
- マージ後、本番で `/api/auth/session` 等が 200 になり `/admin` ログインが通ることを確認予定。