### PR TITLE
chore: 古い proxy.ts/ミドルウェア参照コメントを修正

### DIFF
--- a/app/admin/posts/[id]/page.tsx
+++ b/app/admin/posts/[id]/page.tsx
@@ -6,7 +6,7 @@ import { listMedia } from "@/lib/storage";
 
 export const metadata: Metadata = { title: "記事の編集" };
 
-// /admin 配下のため proxy.ts のミドルウェアで自動的に認証保護される。
+// /admin 配下のため app/admin/layout.tsx の auth() ガードで認証保護される。
 export default async function Page(props: { params: Promise<{ id: string }> }) {
   const { id } = await props.params;
 

--- a/app/admin/posts/new/page.tsx
+++ b/app/admin/posts/new/page.tsx
@@ -5,7 +5,7 @@ import { listMedia } from "@/lib/storage";
 
 export const metadata: Metadata = { title: "記事の新規作成" };
 
-// /admin 配下のため proxy.ts のミドルウェアで自動的に認証保護される。
+// /admin 配下のため app/admin/layout.tsx の auth() ガードで認証保護される。
 export default async function Page() {
   const [categories, media] = await Promise.all([
     fetchCategories(),

--- a/lib/post-actions.ts
+++ b/lib/post-actions.ts
@@ -54,7 +54,7 @@ export async function checkSlugAvailability(
 }
 
 export async function savePost(input: SavePostInput): Promise<PostActionState> {
-  // /admin はミドルウェアで保護されるが、書き込みは多層防御として再確認する。
+  // /admin はレイアウトの auth() ガードで保護されるが、書き込みは多層防御として再確認する。
   const session = await auth();
   if (!session) return { status: "error", message: "認証が必要です。" };
 


### PR DESCRIPTION
## 概要

middleware（`proxy.ts`）廃止後も残っていた、実態とズレたコメントを現状（`app/admin/layout.tsx` の `auth()` ガード）に合わせる。挙動の変更なし・コメントのみ。

## コード

- `app/admin/posts/new/page.tsx` / `app/admin/posts/[id]/page.tsx`: 「proxy.ts のミドルウェアで保護」→「layout の auth() ガードで保護」。
- `lib/post-actions.ts`: 同様にミドルウェア参照を layout ガードへ。

## テスト

- コメントのみの変更。`pnpm lint` / `npx tsc --noEmit` green。