### PR TITLE
fix(admin): 投稿保存時の離脱警告の誤表示を解消し、下書きの URL を任意化 (#53)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env
 .env.local
+.env.staging
 
 # Claude Code (個人ローカル上書きのみ無視。settings.json / hooks / commands は共有)
 .claude/settings.local.json

--- a/components/PostsList.tsx
+++ b/components/PostsList.tsx
@@ -12,9 +12,14 @@ export default function PostsList({title, posts}: { title: string; posts: Post[]
       <ul>
         {posts?.map((post) => (
           <li key={post.id}>
-            <Link href={`/posts/${post.slug}`}>
-              <h2 className="text-2xl text-blue-500 mb-3">{post.title}</h2>
-            </Link>
+            {/* URL 未設定の記事はリンクにしない（多層防御。通常は公開時に URL 必須） */}
+            {post.slug ? (
+              <Link href={`/posts/${post.slug}`}>
+                <h2 className="text-2xl text-blue-500 mb-3">{post.title}</h2>
+              </Link>
+            ) : (
+              <h2 className="text-2xl mb-3">{post.title}</h2>
+            )}
             <PostMetadata
               publishedAt={post.published_at}
               updatedAt={post.updated_at}

--- a/components/admin/PostEditor.tsx
+++ b/components/admin/PostEditor.tsx
@@ -138,8 +138,10 @@ export default function PostEditor({
     }
 
     setFeedback(null);
-    // 保存に伴う遷移では離脱警告を出さない（redirect でこの後 unmount される場合も含む）。
-    isSavingRef.current = true;
+    // 離脱警告の抑止は「新規作成（成功時に編集ページへ redirect する）」のときだけ。
+    // 既存記事の更新は redirect せず（router.refresh のみ）誤発火しないので、保存中も
+    // 離脱ガードを効かせたままにする（通信失敗時の未保存離脱を見逃さない）。
+    isSavingRef.current = !initialPost?.id;
     startSaving(async () => {
       try {
         const result = await savePost({
@@ -372,7 +374,7 @@ export default function PostEditor({
               id="publishedAt"
               value={dateText}
               onChange={(e) => handleDateTextChange(e.target.value)}
-              placeholder="yyyy/mm/dd"
+              placeholder="yyyy/MM/dd"
               className="flex-1"
             />
             <Popover>

--- a/components/admin/PostEditor.tsx
+++ b/components/admin/PostEditor.tsx
@@ -117,6 +117,11 @@ export default function PostEditor({
     isDirtyRef.current = isDirty;
   }, [isDirty]);
 
+  // 保存に伴う意図的な遷移（新規作成後の redirect 等）中は離脱警告を抑止する。
+  // 本番（workerd）ではこの redirect がハードナビゲーションになり、dirty のまま
+  // unload されて beforeunload が誤発火するため、保存中はガードを一律で無効化する。
+  const isSavingRef = React.useRef(false);
+
   // ---- 保存・公開 ----
   const [isSaving, startSaving] = React.useTransition();
   const [feedback, setFeedback] = React.useState<
@@ -133,6 +138,8 @@ export default function PostEditor({
     }
 
     setFeedback(null);
+    // 保存に伴う遷移では離脱警告を出さない（redirect でこの後 unmount される場合も含む）。
+    isSavingRef.current = true;
     startSaving(async () => {
       const result = await savePost({
         id: initialPost?.id,
@@ -146,10 +153,13 @@ export default function PostEditor({
       // 新規作成成功時は Server Action が編集ページへ redirect するため、
       // ここに戻ってくるのはエラー時か既存記事の更新成功時のみ。
       if (result?.status === "error") {
+        // 保存失敗＝遷移しないので、ガードを再武装する。
+        isSavingRef.current = false;
         setFeedback({ type: "error", text: result.message });
       } else {
         // 保存できたので dirty 基準を現在値に更新（離脱警告を解除）。
         setBaseline({ title, slug, category, content, dateText });
+        isSavingRef.current = false;
         setFeedback(
           result?.status === "success"
             ? { type: "success", text: result.message }
@@ -199,11 +209,13 @@ export default function PostEditor({
     if (!isDirty) return;
 
     function onBeforeUnload(e: BeforeUnloadEvent) {
+      if (isSavingRef.current) return; // 保存に伴う遷移は警告しない
       e.preventDefault();
       e.returnValue = "";
     }
 
     function onClickCapture(e: MouseEvent) {
+      if (isSavingRef.current) return; // 保存に伴う遷移は警告しない
       if (
         e.defaultPrevented ||
         e.button !== 0 ||
@@ -256,6 +268,7 @@ export default function PostEditor({
     if (nav) {
       const onNavigate = (e: NavEventLike) => {
         if (e.navigationType !== "traverse" || !e.cancelable) return;
+        if (isSavingRef.current) return; // 保存に伴う遷移は警告しない
         if (isDirtyRef.current && !window.confirm(message)) {
           e.preventDefault(); // 留まる
         }
@@ -267,6 +280,7 @@ export default function PostEditor({
     // フォールバック: sentinel を積んで popstate で受け止める。
     window.history.pushState(null, "", window.location.href);
     const onPopState = () => {
+      if (isSavingRef.current) return; // 保存に伴う遷移は警告しない
       if (isDirtyRef.current && !window.confirm(message)) {
         window.history.pushState(null, "", window.location.href); // 留まる
         return;

--- a/components/admin/PostEditor.tsx
+++ b/components/admin/PostEditor.tsx
@@ -372,7 +372,7 @@ export default function PostEditor({
               id="publishedAt"
               value={dateText}
               onChange={(e) => handleDateTextChange(e.target.value)}
-              placeholder="2026/06/28"
+              placeholder="yyyy/mm/dd"
               className="flex-1"
             />
             <Popover>

--- a/components/admin/PostEditor.tsx
+++ b/components/admin/PostEditor.tsx
@@ -374,7 +374,7 @@ export default function PostEditor({
               id="publishedAt"
               value={dateText}
               onChange={(e) => handleDateTextChange(e.target.value)}
-              placeholder="yyyy/MM/dd"
+              placeholder="yyyy/mm/dd"
               className="flex-1"
             />
             <Popover>

--- a/components/admin/PostEditor.tsx
+++ b/components/admin/PostEditor.tsx
@@ -141,31 +141,44 @@ export default function PostEditor({
     // 保存に伴う遷移では離脱警告を出さない（redirect でこの後 unmount される場合も含む）。
     isSavingRef.current = true;
     startSaving(async () => {
-      const result = await savePost({
-        id: initialPost?.id,
-        title,
-        slug,
-        category,
-        content,
-        publishedAtText: dateText,
-        intent,
-      });
-      // 新規作成成功時は Server Action が編集ページへ redirect するため、
-      // ここに戻ってくるのはエラー時か既存記事の更新成功時のみ。
-      if (result?.status === "error") {
-        // 保存失敗＝遷移しないので、ガードを再武装する。
+      try {
+        const result = await savePost({
+          id: initialPost?.id,
+          title,
+          slug,
+          category,
+          content,
+          publishedAtText: dateText,
+          intent,
+        });
+        // 新規作成成功時は Server Action が編集ページへ redirect するため、
+        // ここに戻ってくるのはエラー時か既存記事の更新成功時のみ。
+        if (result?.status === "error") {
+          // 保存失敗＝遷移しないので、ガードを再武装する。
+          isSavingRef.current = false;
+          setFeedback({ type: "error", text: result.message });
+        } else {
+          // 保存できたので dirty 基準を現在値に更新（離脱警告を解除）。
+          setBaseline({ title, slug, category, content, dateText });
+          isSavingRef.current = false;
+          setFeedback(
+            result?.status === "success"
+              ? { type: "success", text: result.message }
+              : null,
+          );
+          router.refresh();
+        }
+      } catch (error) {
+        // redirect() 由来（NEXT_REDIRECT）は正常な遷移。握りつぶすとナビゲーションが
+        // 壊れるので、そのまま再 throw する。
+        const digest = (error as { digest?: unknown }).digest;
+        if (typeof digest === "string" && digest.startsWith("NEXT_REDIRECT")) {
+          throw error;
+        }
+        // それ以外の例外（通信失敗等）は保存フラグを再武装し、離脱警告を復活させる
+        // （true のまま残すと未保存の変更が黙って失われうるため）。
         isSavingRef.current = false;
-        setFeedback({ type: "error", text: result.message });
-      } else {
-        // 保存できたので dirty 基準を現在値に更新（離脱警告を解除）。
-        setBaseline({ title, slug, category, content, dateText });
-        isSavingRef.current = false;
-        setFeedback(
-          result?.status === "success"
-            ? { type: "success", text: result.message }
-            : null,
-        );
-        router.refresh();
+        setFeedback({ type: "error", text: "保存に失敗しました。" });
       }
     });
   }

--- a/e2e/leave-warning.spec.ts
+++ b/e2e/leave-warning.spec.ts
@@ -1,5 +1,40 @@
 import { test, expect } from "@playwright/test";
 
+// 新規記事を保存すると編集ページへ redirect するが、これは意図した遷移なので
+// 離脱警告（beforeunload / カスタム confirm）が出てはいけない（Issue #53）。
+test("新規保存では離脱警告が出ずに編集ページへ遷移する", async ({ page }) => {
+  const slug = `e2e-leave-${Date.now()}`;
+  const title = `E2E離脱 ${slug}`;
+
+  await page.goto("/admin/posts/new");
+  await page.getByLabel("タイトル").fill(title);
+  await page.locator("#slug").fill(slug);
+  await page.locator("#content").fill("離脱警告テスト本文");
+
+  // 保存に伴う遷移中に離脱系ダイアログが出たら記録（種別は問わず accept して先へ進める）。
+  const leaveDialogs: string[] = [];
+  page.on("dialog", (d) => {
+    const msg = d.message();
+    if (d.type() === "beforeunload" || msg.includes("このページを離れます")) {
+      leaveDialogs.push(msg || d.type());
+    }
+    d.accept().catch(() => {});
+  });
+
+  // 下書き保存（新規は draft でも編集ページへ redirect する＝同じ遷移経路）。
+  await page.getByRole("button", { name: "下書き保存" }).click();
+  await expect(page.getByRole("heading", { name: "記事を編集" })).toBeVisible();
+
+  // 意図した保存遷移なので離脱警告は 1 度も出ないはず。
+  expect(leaveDialogs).toEqual([]);
+
+  // 後始末: 一覧から削除（削除確認は上の handler が accept 済み）。
+  await page.goto("/admin");
+  const row = page.getByRole("row").filter({ hasText: title });
+  await row.getByRole("button", { name: "削除" }).click();
+  await expect(page.getByRole("row").filter({ hasText: title })).toHaveCount(0);
+});
+
 // 未保存の変更があるとき、ブラウザの戻るで確認が出て、OK すると離脱できる。
 test("未保存のまま戻る→確認 OK で離脱できる", async ({ page }) => {
   await page.goto("/admin");

--- a/e2e/post-create.spec.ts
+++ b/e2e/post-create.spec.ts
@@ -35,3 +35,25 @@ test("新規作成して公開し、公開ページに表示される", async ({
   await row.getByRole("button", { name: "削除" }).click();
   await expect(page.getByRole("row").filter({ hasText: title })).toHaveCount(0);
 });
+
+// 下書きは URL（slug）未入力でも保存できる（公開時のみ URL 必須）。
+test("URL 未入力でも下書き保存できる", async ({ page }) => {
+  const title = `E2E下書きURLなし ${Date.now()}`;
+
+  page.on("dialog", (d) => d.accept()); // 削除確認を自動承認
+
+  await page.goto("/admin/posts/new");
+  await page.getByLabel("タイトル").fill(title);
+  await page.locator("#content").fill("URL なし下書き本文");
+
+  // URL 未入力のまま下書き保存 → エラーにならず編集ページへ遷移する。
+  await page.getByRole("button", { name: "下書き保存" }).click();
+  await expect(page.getByRole("heading", { name: "記事を編集" })).toBeVisible();
+  await expect(page.getByText("URLを入力してください。")).toHaveCount(0);
+
+  // 後始末: 一覧から削除
+  await page.goto("/admin");
+  const row = page.getByRole("row").filter({ hasText: title });
+  await row.getByRole("button", { name: "削除" }).click();
+  await expect(page.getByRole("row").filter({ hasText: title })).toHaveCount(0);
+});

--- a/e2e/post-list.spec.ts
+++ b/e2e/post-list.spec.ts
@@ -28,3 +28,37 @@ test("一覧で公開/下書きを切り替え、削除できる", async ({ page
   await row.getByRole("button", { name: "削除" }).click();
   await expect(page.getByRole("row").filter({ hasText: title })).toHaveCount(0);
 });
+
+// URL 未設定の下書きは、一覧の公開トグルからは公開できない（公開には URL 必須）。
+test("URL 未設定の下書きは一覧の公開トグルで公開できない", async ({ page }) => {
+  const title = `E2E公開拒否 ${Date.now()}`;
+
+  const dialogs: string[] = [];
+  page.on("dialog", (d) => {
+    dialogs.push(d.message());
+    d.accept();
+  });
+
+  // URL 未入力で下書きを作成
+  await page.goto("/admin/posts/new");
+  await page.getByLabel("タイトル").fill(title);
+  await page.locator("#content").fill("URL 無し公開拒否テスト");
+  await page.getByRole("button", { name: "下書き保存" }).click();
+  await expect(page.getByRole("heading", { name: "記事を編集" })).toBeVisible();
+
+  // 一覧で公開トグル → URL 必須エラーで公開されず、「下書き」のまま。
+  await page.goto("/admin");
+  const row = page.getByRole("row").filter({ hasText: title });
+  await row.getByRole("button", { name: "下書き", exact: true }).click();
+  // 公開トグルは「確認ダイアログ → サーバーアクション → エラー alert」の順なので alert を待つ。
+  await expect
+    .poll(() => dialogs.some((m) => m.includes("公開するには URL が必要です")))
+    .toBe(true);
+  // 公開されず「下書き」のまま。
+  await expect(row.getByRole("button", { name: "下書き", exact: true })).toBeVisible();
+  await expect(row.getByRole("button", { name: "公開", exact: true })).toHaveCount(0);
+
+  // 後始末: 削除
+  await row.getByRole("button", { name: "削除" }).click();
+  await expect(page.getByRole("row").filter({ hasText: title })).toHaveCount(0);
+});

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -129,7 +129,7 @@ export async function isSlugAvailable(
 // 記事の作成・更新で受け取る値。created_at/updated_at は DB 側で管理する。
 export type PostWriteInput = {
   title: string | null;
-  slug: string;
+  slug: string | null; // 下書きは URL 未設定（null）を許容。公開時のみ必須（呼び出し側で担保）
   category: string | null;
   content: string | null;
   published_at: string | null; // ISO 文字列（Asia/Tokyo で整形済み）または null
@@ -140,9 +140,9 @@ export type PostWriteInput = {
 // ここでは postgres のエラーをそのまま伝播させる。
 export async function createPost(
   input: PostWriteInput,
-): Promise<{ id: string; slug: string }> {
+): Promise<{ id: string; slug: string | null }> {
   const sql = getSql();
-  const rows = await sql<{ id: string; slug: string }[]>`
+  const rows = await sql<{ id: string; slug: string | null }[]>`
     INSERT INTO posts (title, slug, category, content, published_at, is_public)
     VALUES (${input.title}, ${input.slug}, ${input.category}, ${input.content}, ${input.published_at}, ${input.is_public})
     RETURNING id, slug

--- a/lib/post-actions.ts
+++ b/lib/post-actions.ts
@@ -9,6 +9,7 @@ import {
   deletePost,
   setPostPublic,
   isSlugAvailable,
+  fetchPostById,
 } from "@/lib/data";
 import { SLUG_PATTERN, toTokyoISODate } from "@/lib/post-format";
 
@@ -155,6 +156,19 @@ export async function togglePublicAction(
 ): Promise<PostActionState> {
   const session = await auth();
   if (!session) return { status: "error", message: "認証が必要です。" };
+
+  // 下書きは URL(slug) 未設定を許容するため、公開経路でも URL 必須を担保する
+  // （URL 無しで公開すると /posts/<slug> が生成できず公開ページが壊れる）。
+  if (isPublic) {
+    const post = await fetchPostById(id);
+    if (!post) return { status: "error", message: "記事が見つかりません。" };
+    if (!post.slug) {
+      return {
+        status: "error",
+        message: "公開するには URL が必要です。記事を開いて URL を設定してください。",
+      };
+    }
+  }
 
   try {
     await setPostPublic(id, isPublic);

--- a/lib/post-actions.ts
+++ b/lib/post-actions.ts
@@ -63,10 +63,12 @@ export async function savePost(input: SavePostInput): Promise<PostActionState> {
   const category = input.category.trim();
   const publish = input.intent === "publish";
 
-  if (!slug) {
-    return { status: "error", message: "URL（slug）を入力してください。" };
+  // 下書きは URL 未設定で保存できる（DB では slug=NULL）。公開時のみ URL 必須。
+  if (publish && !slug) {
+    return { status: "error", message: "URLを入力してください。" };
   }
-  if (!SLUG_PATTERN.test(slug)) {
+  // URL を入力しているなら（下書き・公開を問わず）書式は検証する。
+  if (slug && !SLUG_PATTERN.test(slug)) {
     return {
       status: "error",
       message:
@@ -89,7 +91,7 @@ export async function savePost(input: SavePostInput): Promise<PostActionState> {
 
   const data = {
     title: title || null,
-    slug,
+    slug: slug || null,
     category: category || null,
     content: input.content || null,
     published_at: publishedAt,

--- a/lib/post-actions.ts
+++ b/lib/post-actions.ts
@@ -84,7 +84,7 @@ export async function savePost(input: SavePostInput): Promise<PostActionState> {
   if (input.publishedAtText.trim() && publishedAt === null) {
     return {
       status: "error",
-      message: "公開日は yyyy/mm/dd 形式で入力してください。",
+      message: "公開日は yyyy/MM/dd 形式で入力してください。",
     };
   }
   // 公開で日付未指定なら現在時刻を公開日時にする。

--- a/lib/post-actions.ts
+++ b/lib/post-actions.ts
@@ -84,7 +84,7 @@ export async function savePost(input: SavePostInput): Promise<PostActionState> {
   if (input.publishedAtText.trim() && publishedAt === null) {
     return {
       status: "error",
-      message: "公開日は 2026/06/28 形式で入力してください。",
+      message: "公開日は yyyy/mm/dd 形式で入力してください。",
     };
   }
   // 公開で日付未指定なら現在時刻を公開日時にする。

--- a/lib/post-actions.ts
+++ b/lib/post-actions.ts
@@ -84,7 +84,7 @@ export async function savePost(input: SavePostInput): Promise<PostActionState> {
   if (input.publishedAtText.trim() && publishedAt === null) {
     return {
       status: "error",
-      message: "公開日は yyyy/MM/dd 形式で入力してください。",
+      message: "公開日は yyyy/mm/dd 形式で入力してください。",
     };
   }
   // 公開で日付未指定なら現在時刻を公開日時にする。


### PR DESCRIPTION
- close #53

## 概要

記事エディタの2つの保存まわりの不具合を修正。

1. **投稿保存時の離脱警告の誤表示 (#53)**
   新規記事の保存は Server Action が編集ページへ `redirect()` するが、redirect で
   `setBaseline` に到達せず `isDirty=true` のまま遷移するため、本番 (workerd/OpenNext)
   の**ハードナビゲーション**で `beforeunload` が「未保存離脱」と誤発火していた。
   （dev は soft nav のため再現せず、本番相当環境固有）
2. **下書きは URL(slug) 未入力でも保存可能に**
   UI は「下書き保存は常に可能」としているのに、サーバーが slug を一律必須にしていた
   不整合を修正。あわせてエラー文言を簡潔化。

## コード

- `components/admin/PostEditor.tsx`: 保存中フラグ `isSavingRef` を追加し、各離脱ガード
  (`beforeunload` / アンカークリック捕捉 / Navigation API / popstate フォールバック) で
  保存中は警告を抑止。保存失敗時は再武装、成功時は `setBaseline` と同時に解除。
- `lib/post-actions.ts`: URL 必須チェックを**公開時のみ**に変更 (`publish && !slug`)。
  書式チェックは URL 入力時のみ。保存値は `slug || null`。文言を
  「URL（slug）を入力してください。」→「URLを入力してください。」に変更。
- `lib/data.ts`: `PostWriteInput.slug` と `createPost` 戻り値を `string | null` に。
  DB 列は `VARCHAR(255) UNIQUE`（NOT NULL ではなく NULL は一意制約対象外）でスキーマ変更なし。

## テスト

- `e2e/leave-warning.spec.ts`: 「新規保存では離脱警告が出ずに編集ページへ遷移する」を追加。
  ※ dev は soft nav のためこのテストは修正前でも green（回帰ガード）。実バグの解消確認は
  staging/preview (workerd) での手動確認が前提。
- `e2e/post-create.spec.ts`: 「URL 未入力でも下書き保存できる」を追加（dev で再現・検証可能）。
- `npx tsc --noEmit` ✅ / `pnpm lint` ✅ / `pnpm test:e2e`（該当スペック）✅ all pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
