### PR TITLE
fix(infra): Hyperdrive クエリキャッシュ無効化で投稿/削除の即時反映を回復 (#55)

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -44,7 +44,13 @@
 
 ### 初回セットアップ（ダッシュボード / 手元作業）
 
-1. **Hyperdrive**（[`hyperdrive`](https://developers.cloudflare.com/hyperdrive/)）を 2 つ作成し ID を [`../wrangler.jsonc`](../wrangler.jsonc) に記入: 本番=prod Neon（top-level）/ staging=dev Neon（`env.staging`）。クエリキャッシュは編集の即時反映のため無効化推奨（`--caching-disabled`）。
+1. **Hyperdrive**（[`hyperdrive`](https://developers.cloudflare.com/hyperdrive/)）を 2 つ作成し ID を [`../wrangler.jsonc`](../wrangler.jsonc) に記入: 本番=prod Neon（top-level）/ staging=dev Neon（`env.staging`）。**クエリキャッシュは無効化する**（`--caching-disabled`）。有効（既定 `max_age` 60秒）だと一覧の SELECT がキャッシュされ、投稿/削除が一覧へ反映されるまで最大 ~60秒遅れる（[#55](https://github.com/akimasanishida/blog.akimasanishida.com/issues/55)）。コネクションプーリングは無効化後も維持される。この設定は Cloudflare リソース側に保持され `wrangler.jsonc` には出ないため、両環境で個別に設定・確認する:
+
+   ```
+   wrangler hyperdrive update <本番ID> --caching-disabled     # prod（blog-neon-prod）
+   wrangler hyperdrive update <stagingID> --caching-disabled  # staging（blog-neon-dev）
+   wrangler hyperdrive get <ID>   # caching.disabled: true を確認
+   ```
 2. **実行時シークレット**を環境ごとに設定（`wrangler secret put <NAME>` は本番、`--env staging` 付きは staging）: `AUTH_SECRET` / `STORAGE_BUCKET_NAME` / `STORAGE_ACCESS_KEY_ID` / `STORAGE_SECRET_ACCESS_KEY` / `STORAGE_ENDPOINT_URL`。
 3. **GitHub Actions** の設定:
    - リポジトリ Secrets: `CLOUDFLARE_API_TOKEN`（Workers 編集権限）/ `CLOUDFLARE_ACCOUNT_ID`。


### PR DESCRIPTION
## 概要

admin・公開ブログの両方で、投稿後に記事一覧へ反映されるまで／削除が反映されるまでに時間がかかる問題（最大 ~60秒）を修正する。

- close #55

**根本原因**: 記事一覧ページ（`app/page.tsx` / `app/admin/page.tsx`）は `searchParams` を読むため動的レンダリングで毎リクエスト DB を直接クエリしているが、prod・staging の Hyperdrive が既定で**クエリキャッシュ有効**（`max_age` 60秒 + `stale_while_revalidate` 15秒）だった。一覧の SELECT（`NOW()` 等の非決定関数を含まずキャッシュ対象）がキャッシュ結果を最大 ~60秒返すため、公開・削除の反映が遅れていた。`revalidatePath` は正しく呼ばれており、Next 側キャッシュは原因ではない。

**対応**: 両 Hyperdrive config のクエリキャッシュを `--caching-disabled` で無効化（Cloudflare リソース側の設定・即時適用・再デプロイ不要）。コネクションプーリング（Workers での主目的）は維持される。

## コード

- **アプリのコード変更なし。** 修正は Cloudflare リソース側の設定変更（`wrangler.jsonc` には現れない）。
- `docs/infrastructure.md`: 初回セットアップの Hyperdrive 手順を実態に合わせ、既存 config も `wrangler hyperdrive update --caching-disabled` で無効化する旨と確認コマンドを追記。

## テスト

適用済み（`wrangler hyperdrive update ... --caching-disabled` → `get` で確認）:

- prod `blog-neon-prod`（`1992c174...`）→ `caching.disabled: true`
- staging `blog-neon-dev`（`f634613f...`）→ `caching.disabled: true`

実地確認（要オーナー）: 新規公開/削除/公開↔下書きトグルが `/`・`/admin` の一覧へ即時反映されること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)