### PR TITLE
fix(editor): メディア挿入ダイアログの画像一覧をスクロール可能に (#62)

### DIFF
--- a/components/admin/PostEditor.tsx
+++ b/components/admin/PostEditor.tsx
@@ -777,7 +777,7 @@ function MediaPickerDialog({
           メディアを挿入
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-4xl" aria-describedby={undefined}>
+      <DialogContent className="flex max-h-[85dvh] flex-col sm:max-w-4xl" aria-describedby={undefined}>
         <DialogHeader>
           <DialogTitle>メディアを挿入</DialogTitle>
         </DialogHeader>
@@ -787,7 +787,7 @@ function MediaPickerDialog({
             メディアがまだありません。「メディアを追加」からアップロードしてください。
           </p>
         ) : (
-          <div className="grid max-h-[60vh] grid-cols-2 gap-3 overflow-y-auto p-1 sm:grid-cols-3">
+          <div className="grid min-h-0 flex-1 auto-rows-max grid-cols-2 gap-3 overflow-y-auto p-1 sm:grid-cols-3">
             {media.map((item) => {
               const isActive = selected?.key === item.key;
               return (


### PR DESCRIPTION
- close #62

## 概要

記事編集ページの「メディアを挿入」ダイアログで、画像枚数が多いと各画像が潰れて表示され、各画像の「選択」ボタンやフッターの「貼り付け」ボタンが画面外に隠れて到達できなかった不具合を修正。

原因は画像グリッドが `display:grid` の暗黙行 `grid-auto-rows:auto` のまま高さ制約下に置かれ、`overflow-y-auto` があっても行が潰れてスクロールが発生していなかったこと（＝そもそもスクロールしていなかった）。

## コード

`components/admin/PostEditor.tsx`（`MediaPickerDialog`）の className のみ変更（共有 `dialog.tsx` は不変更）:

- `DialogContent` を `flex max-h-[85dvh] flex-col` に。ダイアログ全体を高さ上限付き flex 縦積みにして viewport 内に収める（`cn()` の twMerge により基底の `grid` を `flex` で上書き）。
- 画像グリッドを `flex-1 min-h-0 auto-rows-max` に。**`auto-rows-max`（`grid-auto-rows:max-content`）** で各行が画像の高さを保ったままあふれ、グリッド内部だけがスクロールする。

これでヘッダー・「メディアを追加」・キャプション・「貼り付け」は常時表示され、画像一覧部分だけがスクロールする。

## テスト

- `pnpm lint` / `npx tsc --noEmit` パス。
- 同一 DOM 構造・同一計算 CSS を Chromium(Playwright) で 30 枚・低い画面高で描画して計測・目視確認:

  | | 修正前 | 修正後 |
  |---|---|---|
  | グリッドが実際にスクロール | ❌ | ✅ (`scrollHeight 2571 / client 176`) |
  | 先頭セルの高さ | 20px（潰れ） | 246px（画像フル表示） |
  | フッター「貼り付け」が画面内 | ❌ 隠れる | ✅ 表示 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)