### PR TITLE
feat(editor): 記事の公開/更新後に投稿完了ページへ遷移 (#54)

### DIFF
--- a/app/admin/posts/[id]/complete/page.tsx
+++ b/app/admin/posts/[id]/complete/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { CheckCircle2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { fetchPostById } from "@/lib/data";
+
+export const metadata: Metadata = { title: "投稿完了" };
+
+// /admin 配下のため app/admin/layout.tsx の auth() ガードで認証保護される。
+export default async function Page(props: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ updated?: string }>;
+}) {
+  const { id } = await props.params;
+  const { updated } = await props.searchParams;
+
+  const post = await fetchPostById(id);
+  if (!post) notFound();
+  // 完了ページは公開/更新後（is_public=true）にのみ遷移してくる。下書き id で
+  // 直接アクセスされた場合は「公開しました」と食い違うため 404 にする。
+  if (!post.is_public) notFound();
+
+  const canView = Boolean(post.slug);
+  // 既存記事の更新は savePost が ?updated=1 を付けて遷移してくる。
+  const action = updated ? "更新" : "公開";
+
+  return (
+    <div className="container mx-auto flex max-w-xl flex-col items-center gap-6 py-16 text-center">
+      <CheckCircle2 className="h-12 w-12 text-green-600 dark:text-green-500" />
+      <div className="flex flex-col gap-2">
+        <h1 className="text-2xl font-bold">投稿が完了しました</h1>
+        <p className="text-muted-foreground">
+          「{post.title ?? "無題"}」を{action}しました。
+        </p>
+      </div>
+      <div className="flex flex-wrap justify-center gap-3">
+        {canView && (
+          <Button asChild>
+            <Link href={`/posts/${post.slug}`}>記事を見る</Link>
+          </Button>
+        )}
+        <Button asChild variant="outline">
+          <Link href="/admin">管理画面トップに戻る</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/PostEditor.tsx
+++ b/components/admin/PostEditor.tsx
@@ -138,10 +138,13 @@ export default function PostEditor({
     }
 
     setFeedback(null);
-    // 離脱警告の抑止は「新規作成（成功時に編集ページへ redirect する）」のときだけ。
-    // 既存記事の更新は redirect せず（router.refresh のみ）誤発火しないので、保存中も
-    // 離脱ガードを効かせたままにする（通信失敗時の未保存離脱を見逃さない）。
-    isSavingRef.current = !initialPost?.id;
+    // 離脱警告の抑止は「保存に伴い redirect する」ときだけ。redirect するのは
+    // 新規保存（成功時に編集ページ / 完了ページへ）と公開・更新（完了ページへ）。
+    // 本番（workerd）ではこの redirect がハードナビゲーションになり、dirty のまま
+    // unload されて beforeunload が誤発火するため、その間だけガードを無効化する。
+    // 既存記事の下書き保存だけは redirect せず（router.refresh のみ）誤発火しないので、
+    // 保存中も離脱ガードを効かせたままにする（通信失敗時の未保存離脱を見逃さない）。
+    isSavingRef.current = !initialPost?.id || intent === "publish";
     startSaving(async () => {
       try {
         const result = await savePost({
@@ -153,8 +156,8 @@ export default function PostEditor({
           publishedAtText: dateText,
           intent,
         });
-        // 新規作成成功時は Server Action が編集ページへ redirect するため、
-        // ここに戻ってくるのはエラー時か既存記事の更新成功時のみ。
+        // 新規保存・公開・更新の成功時は Server Action が別ページへ redirect するため、
+        // ここに戻ってくるのはエラー時か既存記事の下書き保存成功時のみ。
         if (result?.status === "error") {
           // 保存失敗＝遷移しないので、ガードを再武装する。
           isSavingRef.current = false;

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -14,6 +14,7 @@
 | メディア管理 | `/admin/media` | メディア一覧・アップロード・削除・リネーム（認証付き、R2 の `media/` を直接 List） | ✅ | [`app/admin/media/page.tsx`](../app/admin/media/page.tsx) / [`lib/storage.ts`](../lib/storage.ts) |
 | 記事の新規作成 | `/admin/posts/new` | 記事エディタ（認証付き）。タイトル/URL/カテゴリー候補/公開日/本文・メディア挿入・プレビュー・下書き/公開（#9） | ✅ | [`app/admin/posts/new/page.tsx`](../app/admin/posts/new/page.tsx) / [`components/admin/PostEditor.tsx`](../components/admin/PostEditor.tsx) |
 | 記事の編集 | `/admin/posts/[id]` | 記事エディタ（認証付き）。id で実記事をロードし更新（#9） | ✅ | [`app/admin/posts/[id]/page.tsx`](../app/admin/posts/%5Bid%5D/page.tsx) |
+| 投稿完了 | `/admin/posts/[id]/complete` | 公開/更新後の完了画面（記事を見る／管理トップ導線・#54） | ✅ | [`app/admin/posts/[id]/complete/page.tsx`](../app/admin/posts/%5Bid%5D/complete/page.tsx) |
 | アーカイブ（年） | `/archives/[year]` | 指定年の記事 | 🚧 | — |
 | アーカイブ（月） | `/archives/[year]/[month]` | 指定年月の記事 | 🚧 | — |
 | カテゴリー | `/categories/[category]` | 指定カテゴリーの記事 | 🚧 | — |

--- a/e2e/post-complete.spec.ts
+++ b/e2e/post-complete.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from "@playwright/test";
+
+// issue #54: 記事投稿後は完了ページへ遷移し、「記事を見る」「管理画面トップに戻る」導線を出す。
+// また、完了ページから戻っても新規作成フォームに投稿内容が残らない（stale 復元しない）。
+
+// 一覧から記事を削除する後始末（削除確認ダイアログは呼び出し側で accept 登録済み）。
+async function cleanup(page: import("@playwright/test").Page, title: string) {
+  await page.goto("/admin");
+  const row = page.getByRole("row").filter({ hasText: title });
+  await row.getByRole("button", { name: "削除" }).click();
+  await expect(page.getByRole("row").filter({ hasText: title })).toHaveCount(0);
+}
+
+test("新規公開後の完了ページに導線が出て、記事を見るで公開ページへ遷移する", async ({
+  page,
+}) => {
+  const slug = `e2e-complete-${Date.now()}`;
+  const title = `E2E完了 ${slug}`;
+
+  page.on("dialog", (d) => d.accept()); // 公開確認・削除確認を自動承認
+
+  await page.goto("/admin/posts/new");
+  await page.getByLabel("タイトル").fill(title);
+  await page.locator("#slug").fill(slug);
+  await page.locator("#content").fill("完了ページテスト本文");
+
+  await page.getByRole("button", { name: "公開", exact: true }).click();
+
+  // 完了ページ表示 + 2 つの導線
+  await page.waitForURL("**/admin/posts/*/complete");
+  await expect(
+    page.getByRole("heading", { name: "投稿が完了しました" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: "管理画面トップに戻る" }),
+  ).toHaveAttribute("href", "/admin");
+
+  // 「記事を見る」→ 公開ページ（/posts/[slug]）へ
+  const viewLink = page.getByRole("link", { name: "記事を見る" });
+  await expect(viewLink).toHaveAttribute("href", `/posts/${slug}`);
+  await viewLink.click();
+  await page.waitForURL(`**/posts/${slug}`);
+  await expect(page.getByRole("heading", { name: title })).toBeVisible();
+
+  await cleanup(page, title);
+});
+
+test("完了ページから戻っても新規作成フォームに投稿内容が残らない", async ({
+  page,
+}) => {
+  const slug = `e2e-back-${Date.now()}`;
+  const title = `E2E戻る ${slug}`;
+
+  page.on("dialog", (d) => d.accept());
+
+  // /admin → 新規作成 の順に遷移してから公開する（履歴を実運用に近づける）。
+  await page.goto("/admin");
+  await page.getByRole("link", { name: "新規作成", exact: true }).click();
+  await page.waitForURL("**/admin/posts/new");
+
+  await page.getByLabel("タイトル").fill(title);
+  await page.locator("#slug").fill(slug);
+  await page.locator("#content").fill("戻るテスト本文");
+
+  await page.getByRole("button", { name: "公開", exact: true }).click();
+  await page.waitForURL("**/admin/posts/*/complete");
+
+  // 新規公開は replace 遷移なので、戻ると新規フォームではなく /admin に戻る。
+  await page.goBack();
+  await expect(page).toHaveURL(/\/admin(\?.*)?$/);
+  await expect(
+    page.getByRole("heading", { name: "記事を新規作成" }),
+  ).toHaveCount(0);
+
+  await cleanup(page, title);
+});
+
+test("既存記事の更新後も完了ページへ遷移し、戻ると編集ページに戻れる", async ({
+  page,
+}) => {
+  const slug = `e2e-update-${Date.now()}`;
+  const title = `E2E更新 ${slug}`;
+
+  page.on("dialog", (d) => d.accept()); // 公開・更新・削除の確認を自動承認
+
+  // まず新規公開して記事を作り、完了ページの URL から id を取り出す。
+  await page.goto("/admin/posts/new");
+  await page.getByLabel("タイトル").fill(title);
+  await page.locator("#slug").fill(slug);
+  await page.locator("#content").fill("更新前の本文");
+  await page.getByRole("button", { name: "公開", exact: true }).click();
+  await page.waitForURL("**/admin/posts/*/complete");
+  const id = page.url().match(/\/admin\/posts\/([^/]+)\/complete/)?.[1];
+  expect(id).toBeTruthy();
+
+  // 編集ページを開いて本文を変更 → 「更新」
+  await page.goto(`/admin/posts/${id}`);
+  await expect(page.getByRole("heading", { name: "記事を編集" })).toBeVisible();
+  await page.locator("#content").fill("更新後の本文");
+  await page.getByRole("button", { name: "更新", exact: true }).click();
+
+  // 既存更新も完了ページへ（push 遷移・?updated=1 で「更新しました」表示）
+  await page.waitForURL("**/admin/posts/*/complete?updated=1");
+  await expect(
+    page.getByRole("heading", { name: "投稿が完了しました" }),
+  ).toBeVisible();
+  await expect(page.getByText(`「${title}」を更新しました。`)).toBeVisible();
+
+  // push 遷移なので戻ると編集ページに戻れる
+  await page.goBack();
+  await expect(page.getByRole("heading", { name: "記事を編集" })).toBeVisible();
+
+  await cleanup(page, title);
+});

--- a/e2e/post-create.spec.ts
+++ b/e2e/post-create.spec.ts
@@ -16,9 +16,11 @@ test("新規作成して公開し、公開ページに表示される", async ({
   await page.locator("#slug").fill(slug);
   await page.locator("#content").fill("# 見出し\n\n本文テストです。");
 
-  // 公開（新規作成成功で編集ページへリダイレクトされる）
+  // 公開（新規作成成功で投稿完了ページへリダイレクトされる）
   await page.getByRole("button", { name: "公開", exact: true }).click();
-  await expect(page.getByRole("heading", { name: "記事を編集" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "投稿が完了しました" }),
+  ).toBeVisible();
 
   // 一覧に出現
   await page.goto("/admin");

--- a/lib/post-actions.ts
+++ b/lib/post-actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { redirect } from "next/navigation";
+import { redirect, RedirectType } from "next/navigation";
 import { auth } from "@/auth";
 import {
   createPost,
@@ -124,14 +124,24 @@ export async function savePost(input: SavePostInput): Promise<PostActionState> {
     revalidatePath(`/posts/${slug}`);
   }
 
-  // 新規作成後は編集ページへ遷移し、以後は更新として扱う。
   // redirect は NEXT_REDIRECT を throw するため try/catch の外で呼ぶ。
-  if (newId) redirect(`/admin/posts/${newId}`);
+  const savedId = input.id ?? newId;
+  // 公開/更新（intent=publish）は完了ページへ。新規は back で新規フォーム（スタレ）に
+  // 戻さないよう replace、既存更新は back で編集画面に戻れるよう push。
+  // 既存更新は文言を出し分けるため ?updated=1 を付ける。
+  if (publish && savedId) {
+    redirect(
+      input.id
+        ? `/admin/posts/${savedId}/complete?updated=1`
+        : `/admin/posts/${savedId}/complete`,
+      input.id ? RedirectType.push : RedirectType.replace,
+    );
+  }
+  // 新規の下書き保存は従来どおり編集ページへ（back のスタレ防止に replace）。
+  if (newId) redirect(`/admin/posts/${newId}`, RedirectType.replace);
 
-  return {
-    status: "success",
-    message: publish ? "公開しました。" : "下書きを保存しました。",
-  };
+  // 既存の下書き保存はページ内フィードバックのまま。
+  return { status: "success", message: "下書きを保存しました。" };
 }
 
 export async function deletePostAction(id: string): Promise<PostActionState> {


### PR DESCRIPTION
- close #54

## 概要

記事の公開/更新後に投稿完了ページ（`/admin/posts/[id]/complete`）へ遷移させ、「記事を見る」「管理画面トップに戻る」の導線を追加する。あわせて、公開後にブラウザの「戻る」で新規作成フォームに投稿内容が復元される問題（issue #54 の主眼）を解消する。

## コード

- 完了ページを新設（`app/admin/posts/[id]/complete/page.tsx`）。公開済み記事のみ表示（下書き id は `notFound`）、既存更新は `?updated=1` で「公開しました／更新しました」を出し分け。
- `savePost`（`lib/post-actions.ts`）: 公開/更新後は完了ページへ。新規は **replace**（戻るで新規フォームに戻さない）、既存更新は **push**（戻るで編集ページへ）。新規の下書き保存も replace で編集ページへ。
- `PostEditor`（`components/admin/PostEditor.tsx`）: 公開/更新も redirect するため、離脱ガード抑止条件を `!initialPost?.id || intent === "publish"` に拡張し `beforeunload` の誤発火を防止。
- `docs/routing.md` に完了ページのルートを追記（スキーマ変更なしのため data-model.md は変更なし）。

## テスト

- `pnpm lint` / `npx tsc --noEmit` / `pnpm test`（Vitest 21）: すべてパス。
- E2E `pnpm test:e2e`: 11 passed。`post-create.spec.ts` を完了ページ経由に更新し、`post-complete.spec.ts` を新規追加（新規公開の導線／戻るで stale 復元しない／既存更新の完了ページ・「更新しました」文言・戻るで編集ページ）。
- コードレビュー（code-reviewer サブエージェント）: PASS。指摘 3 件（文言出し分け・下書き直アクセス 404・`canView` の型）を反映済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)